### PR TITLE
refactor(core): replace illegal STR interpolations and bump Java release to 23

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,16 +17,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
-                    <compilerArgs>--enable-preview</compilerArgs>
+                    <source>23</source>
+                    <target>23</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
     <properties>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
@@ -82,13 +81,13 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.75.Final</version>
+            <version>4.2.1.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>4.1.75.Final</version>
+            <version>4.2.1.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/api/src/main/java/habbo/furniture/extra/data/ExtraDataType.java
+++ b/api/src/main/java/habbo/furniture/extra/data/ExtraDataType.java
@@ -19,7 +19,7 @@ public enum ExtraDataType {
         final var types = new HashSet<ExtraDataType>();
         for (ExtraDataType type : values()) {
             if (types.contains(type))
-                throw new IllegalArgumentException(STR."Duplicate type: \{type}");
+                throw new IllegalArgumentException("Duplicate type:" + type);
 
             types.add(type);
         }

--- a/api/src/main/java/habbo/rooms/components/gamemap/TileState.java
+++ b/api/src/main/java/habbo/rooms/components/gamemap/TileState.java
@@ -17,10 +17,11 @@ public enum TileState {
     ;
 
     static {
-        var flags = new HashSet<Integer>();
+        final var flags = new HashSet<Integer>();
         for (TileState state : TileState.values()) {
-            if (!flags.add(state.flags))
-                throw new IllegalStateException(STR."Illegal state flag \{state}");
+            if (!flags.add(state.flags)) {
+                throw new IllegalStateException("Illegal state flag " + state);
+            }
         }
     }
 

--- a/api/src/main/java/utils/ReflectionHelpers.java
+++ b/api/src/main/java/utils/ReflectionHelpers.java
@@ -1,12 +1,8 @@
 package utils;
 
 public final class ReflectionHelpers {
-    private ReflectionHelpers() {
-    }
-
     public static CallerInfo getCallerInfo() {
-        // [0]=getStackTrace, [1]=getCallerInfo, [2]=your caller
-        final var stackTraceElement = Thread.currentThread().getStackTrace()[2];
+        final var stackTraceElement = Thread.currentThread().getStackTrace()[3];
         final var className = stackTraceElement.getClassName();
         final var methodName = stackTraceElement.getMethodName();
         final var callerLine = stackTraceElement.getLineNumber();

--- a/api/src/main/java/utils/ReflectionHelpers.java
+++ b/api/src/main/java/utils/ReflectionHelpers.java
@@ -1,8 +1,12 @@
 package utils;
 
 public final class ReflectionHelpers {
+    private ReflectionHelpers() {
+    }
+
     public static CallerInfo getCallerInfo() {
-        final var stackTraceElement = Thread.currentThread().getStackTrace()[3];
+        // [0]=getStackTrace, [1]=getCallerInfo, [2]=your caller
+        final var stackTraceElement = Thread.currentThread().getStackTrace()[2];
         final var className = stackTraceElement.getClassName();
         final var methodName = stackTraceElement.getMethodName();
         final var callerLine = stackTraceElement.getLineNumber();
@@ -12,7 +16,7 @@ public final class ReflectionHelpers {
     public record CallerInfo(String className, String methodName, int line) {
         @Override
         public String toString() {
-            return STR."\{this.className}.\{this.methodName}:\{this.line}";
+            return className + "." + methodName + ":" + line;
         }
     }
 }

--- a/api/src/main/java/utils/gson/InstantTypeAdapter.java
+++ b/api/src/main/java/utils/gson/InstantTypeAdapter.java
@@ -1,22 +1,22 @@
 package utils.gson;
 
 import com.google.gson.*;
-
 import java.lang.reflect.Type;
 import java.time.Instant;
 
 public final class InstantTypeAdapter implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+
     @Override
-    public JsonElement serialize(final Instant src, final Type typeOfSrc, final JsonSerializationContext context) {
+    public JsonElement serialize(Instant src, Type typeOfSrc, JsonSerializationContext context) {
         return new JsonPrimitive(src.toString());
     }
 
     @Override
-    public Instant deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context) throws JsonParseException {
+    public Instant deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         try {
             return Instant.parse(json.getAsString());
         } catch (Exception e) {
-            throw new JsonParseException(STR."Error parsing Instant: \{json.getAsString()}", e);
+            throw new JsonParseException("Error parsing Instant: " + json.getAsString(), e);
         }
     }
 }

--- a/api/src/main/java/utils/gson/InstantTypeAdapter.java
+++ b/api/src/main/java/utils/gson/InstantTypeAdapter.java
@@ -7,12 +7,12 @@ import java.time.Instant;
 public final class InstantTypeAdapter implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
 
     @Override
-    public JsonElement serialize(Instant src, Type typeOfSrc, JsonSerializationContext context) {
+    public JsonElement serialize(final Instant src, final Type typeOfSrc, final JsonSerializationContext context) {
         return new JsonPrimitive(src.toString());
     }
 
     @Override
-    public Instant deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    public Instant deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context) throws JsonParseException {
         try {
             return Instant.parse(json.getAsString());
         } catch (Exception e) {

--- a/emulator/pom.xml
+++ b/emulator/pom.xml
@@ -10,9 +10,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
-                    <compilerArgs>--enable-preview</compilerArgs>
+                    <source>23</source>
+                    <target>23</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -79,8 +78,8 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/emulator/src/main/java/core/concurrency/ThreadManager.java
+++ b/emulator/src/main/java/core/concurrency/ThreadManager.java
@@ -39,17 +39,22 @@ public class ThreadManager implements IThreadManager {
         assert hardwareThreadCount > 0;
         assert softwareThreadCount > 0;
 
-        this.hardwareThreadExecutor = new AtomicReference<>(new ScheduledThreadPoolExecutor(hardwareThreadCount, runnable -> {
-            var currentId = this.hardwareThreadCounter.incrementAndGet();
+        this.hardwareThreadExecutor = new AtomicReference<>(
+                new ScheduledThreadPoolExecutor(hardwareThreadCount, runnable -> {
+                    var currentId = this.hardwareThreadCounter.incrementAndGet();
 
-            var hardwareThread = new Thread(runnable);
-            hardwareThread.setName(STR."Hardware-Thread-\{currentId}");
+                    Thread hardwareThread = new Thread(runnable);
+                    String threadName = "Hardware-Thread-" + currentId;
+                    hardwareThread.setName(threadName);
 
-            var log = LogManager.getLogger(STR."Hardware-Thread-\{currentId}");
-            hardwareThread.setUncaughtExceptionHandler((t, e) -> log.error("Exception in hardware thread: {}", e.getMessage(), e));
+                    Logger log = LogManager.getLogger(threadName);
+                    hardwareThread.setUncaughtExceptionHandler((t, e) ->
+                            log.error("Exception in hardware thread: {}", e.getMessage(), e)
+                    );
 
-            return hardwareThread;
-        }));
+                    return hardwareThread;
+                })
+        );
 
         this.softwareThreadExecutor = new AtomicReference<>(new ScheduledThreadPoolExecutor(softwareThreadCount, Thread.ofVirtual().factory()));
         if (this.configurationManager.getBool("orion.monitor.enabled", false)) {

--- a/emulator/src/main/java/core/configuration/EmulatorSettings.java
+++ b/emulator/src/main/java/core/configuration/EmulatorSettings.java
@@ -39,7 +39,10 @@ public class EmulatorSettings implements IEmulatorSettings {
             this.settings.put(result.getString("key"), result.getString("value"));
         });
 
-        this.logger.info(STR."Loaded \{this.settings.size()} emulator settings from database.");
+        this.logger.info(
+                "Loaded {} emulator settings from database.",
+                this.settings.size()
+        );
 
         this.isLoaded = true;
     }

--- a/emulator/src/main/java/core/events/EventHandler.java
+++ b/emulator/src/main/java/core/events/EventHandler.java
@@ -54,9 +54,11 @@ public class EventHandler implements IEventHandler {
         for (File file : files) {
             if (file.isDirectory()) {
                 assert !file.getName().contains(".");
-                classes.addAll(this.findClasses(file, STR."\{packageName}.\{file.getName()}"));
+                String subPackage = packageName + "." + file.getName();
+                classes.addAll(this.findClasses(file, subPackage));
             } else if (file.getName().endsWith(".class")) {
-                classes.add(Class.forName(packageName + '.' + file.getName().substring(0, file.getName().length() - 6)));
+                String className = file.getName().substring(0, file.getName().length() - 6);
+                classes.add(Class.forName(packageName + '.' + className));
             }
         }
         return classes;

--- a/emulator/src/main/java/core/locking/LockValue.java
+++ b/emulator/src/main/java/core/locking/LockValue.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Nullable;
 
 public record LockValue(@NotNull String key) implements ILockValue {
     public static LockValue fromType(ILockType type, @Nullable String key) {
-        return new LockValue(STR."\{type.getLockCode()}}-\{key}");
+        String k = (key != null ? key : "");
+        return new LockValue(type.getLockCode() + "-" + k);
     }
 }

--- a/emulator/src/main/java/core/plugins/PluginManager.java
+++ b/emulator/src/main/java/core/plugins/PluginManager.java
@@ -106,7 +106,13 @@ public class PluginManager implements IPluginManager {
                     final var classLoader = URLClassLoader.newInstance(new URL[]{pluginFile.toURI().toURL()},
                             this.getClass().getClassLoader());
                     final var pluginConfiguration = new Properties();
-                    pluginConfiguration.load(new FileReader(STR."\{pluginFile.getParent()}\\plugin.ini"));
+                    pluginConfiguration.load(
+                            new FileReader(
+                                    pluginFile.getParent()
+                                            + File.separator
+                                            + "plugin.ini"
+                            )
+                    );
                     final var pluginClass = classLoader.loadClass(pluginConfiguration.getProperty("plugin.entrypoint"));
                     final var pluginInstance = ((IPlugin) pluginClass.getDeclaredConstructor().newInstance());
                     final var pluginClasses = getClassesInPackage(pluginClass.getPackageName(), pluginFile.getPath(),

--- a/emulator/src/main/java/habbo/catalog/CatalogManager.java
+++ b/emulator/src/main/java/habbo/catalog/CatalogManager.java
@@ -71,8 +71,10 @@ public class CatalogManager implements ICatalogManager {
                 this.logger.error("Error while trying to fetch catalog item {}", result.getInt("id"), e);
             }
         });
-        this.logger.info(STR."Loaded \{this.catalogItems.size()} catalog items from database.");
-
+        this.logger.info(
+                "Loaded {} catalog items from database.",
+                this.catalogItems.size()
+        );
 
         this.catalogRepository.getAllCatalogPages(result -> {
             if (result == null) return;
@@ -91,7 +93,10 @@ public class CatalogManager implements ICatalogManager {
                 this.logger.error("Error while trying to fetch catalog page{}", result.getInt("id"), e);
             }
         });
-        this.logger.info(STR."Loaded \{this.catalogPages.size()} catalog pages from database.");
+        this.logger.info(
+                "Loaded {} catalog pages from database.",
+                this.catalogPages.size()
+        );
 
         for (var catalogPage : this.catalogPages.values()) {
             var parent = this.catalogPages.get(catalogPage.getParentId());

--- a/emulator/src/main/java/habbo/catalog/item/CatalogItem.java
+++ b/emulator/src/main/java/habbo/catalog/item/CatalogItem.java
@@ -202,9 +202,10 @@ public class CatalogItem implements ICatalogItem {
             }
         }
 
-        packet.appendInt(0)// TODO clubOnly
+        packet
+                .appendInt(0) // TODO clubOnly
                 .appendBoolean(this.allowOffer(), "_bundlePurchaseAllowed") // TODO
                 .appendBoolean(false, "_isPet")
-                .appendString(STR."\{this.getDisplayName()}.png");
+                .appendString(this.getDisplayName() + ".png");
     }
 }

--- a/emulator/src/main/java/habbo/furniture/FurnitureManager.java
+++ b/emulator/src/main/java/habbo/furniture/FurnitureManager.java
@@ -18,7 +18,7 @@ public class FurnitureManager implements IFurnitureManager {
     private final IFurnitureRepository furnitureRepository;
     private final HashMap<Integer, IFurniture> furnitures;
     private final IFurnitureFactory furnitureFactory;
-    private final Logger logger = LogManager.getLogger();
+    private final Logger logger = LogManager.getLogger(FurnitureManager.class);
 
     private final HashMap<Integer, Class<? extends ExtraData>> extraDataParsers;
 
@@ -32,7 +32,7 @@ public class FurnitureManager implements IFurnitureManager {
 
     @Override
     public void init() {
-        this.logger.info("Initializing furniture's from database...");
+        logger.info("Initializing furniture's from database...");
         this.extraDataParsers.put(ExtraDataType.Empty.getType(), EmptyExtraData.class);
         this.extraDataParsers.put(ExtraDataType.Legacy.getType(), LegacyExtraData.class);
         this.extraDataParsers.put(ExtraDataType.Map.getType(), MapExtraData.class);
@@ -45,7 +45,10 @@ public class FurnitureManager implements IFurnitureManager {
             this.furnitures.put(furniture.getId(), furniture);
         });
 
-        this.logger.info(STR."Loaded \{this.furnitures.size()} furniture from database.");
+        logger.info(
+                "Loaded {} furniture from database.",
+                this.furnitures.size()
+        );
     }
 
     @Override
@@ -68,17 +71,29 @@ public class FurnitureManager implements IFurnitureManager {
     public IExtraData parseExtraData(String json) {
         if (StringUtil.isNullOrEmpty(json))
             return new LegacyExtraData("");
-        
+
         try {
-            var extraDataType = GsonHelper.getGson().fromJson(json, ExtraData.ExtraDataReader.class).type;
-            if (this.extraDataParsers.containsKey(extraDataType))
-                return GsonHelper.getGson().fromJson(json, this.extraDataParsers.get(extraDataType));
+            var extraDataType = GsonHelper.getGson()
+                    .fromJson(json, ExtraData.ExtraDataReader.class)
+                    .type;
+
+            if (this.extraDataParsers.containsKey(extraDataType)) {
+                return GsonHelper.getGson()
+                        .fromJson(json, this.extraDataParsers.get(extraDataType));
+            }
 
             return GsonHelper.getGson().fromJson(json, LegacyExtraData.class);
+
         } catch (JsonSyntaxException _) {
+            // fall through to fallback
         } catch (Exception e) {
-            this.logger.warn(STR."Failed to parse extra data: \{json}", e);
+            logger.warn(
+                    "Failed to parse extra data: {}",
+                    json,
+                    e
+            );
         }
+
         return LegacyExtraData.fromLegacyString(json);
     }
 }

--- a/emulator/src/main/java/habbo/habbos/data/HabboData.java
+++ b/emulator/src/main/java/habbo/habbos/data/HabboData.java
@@ -42,7 +42,11 @@ public class HabboData implements IHabboData, IFillable {
         try {
             this.fill(data);
         } catch (Exception e) {
-            this.logger.error(STR."Failed to create HabboData from IConnectionResult: \{e.getMessage()}");
+            logger.error(
+                    "Failed to create HabboData from IConnectionResult: {}",
+                    e.getMessage(),
+                    e
+            );
         }
     }
 

--- a/emulator/src/main/java/habbo/habbos/data/HabboSettings.java
+++ b/emulator/src/main/java/habbo/habbos/data/HabboSettings.java
@@ -56,7 +56,11 @@ public class HabboSettings implements IHabboSettings, IFillable {
         try {
             this.fill(result);
         } catch (Exception e) {
-            logger.error(STR."Failed to create HabboSettings from IConnectionResult: \{e.getMessage()}");
+            logger.error(
+                    "Failed to create HabboSettings from IConnectionResult: {}",
+                    e.getMessage(),
+                    e
+            );
         }
     }
 

--- a/emulator/src/main/java/habbo/habbos/data/navigator/HabboNavigatorWindowSettings.java
+++ b/emulator/src/main/java/habbo/habbos/data/navigator/HabboNavigatorWindowSettings.java
@@ -22,7 +22,11 @@ public class HabboNavigatorWindowSettings implements IHabboNavigatorWindowSettin
         try {
             this.fillOrCreate(result);
         } catch (Exception e) {
-            this.logger.error(STR."Failed to create HabboNavigatorWindowSettings from IConnectionResult: \{e.getMessage()}");
+            this.logger.error(
+                    "Failed to create HabboNavigatorWindowSettings from IConnectionResult: {}",
+                    e.getMessage(),
+                    e
+            );
         }
     }
 

--- a/emulator/src/main/java/habbo/habbos/factories/HabboInventoryItem.java
+++ b/emulator/src/main/java/habbo/habbos/factories/HabboInventoryItem.java
@@ -77,13 +77,18 @@ public class HabboInventoryItem implements IHabboInventoryItem {
     public void fill(IConnectionResult result) throws Exception {
         this.id = result.getInt("id");
         this.furniture = this.furnitureManager.get(result.getInt("item_id"));
-        if (this.furniture == null)
-            throw new IllegalArgumentException(STR."Invalid furniture base id for item id \{this.id}");
+        if (this.furniture == null) {
+            throw new IllegalArgumentException(
+                    "Invalid furniture base id for item id " + this.id
+            );
+        }
 
         this.extraData = this.furnitureManager.parseExtraData(result.getString("extra_data"));
-        this.extraData.setLimitedData(LimitedData.fromString(result.getString("limited_data")));
+        this.extraData.setLimitedData(
+                LimitedData.fromString(result.getString("limited_data"))
+        );
         this.wiredData = result.getString("wired_data");
-        this.group = result.getInt("guild_id");
+        this.group     = result.getInt("guild_id");
     }
 
     /*

--- a/emulator/src/main/java/habbo/rooms/components/gamemap/RoomGameMap.java
+++ b/emulator/src/main/java/habbo/rooms/components/gamemap/RoomGameMap.java
@@ -16,15 +16,14 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class RoomGameMap implements IRoomGameMap {
-    private final Logger logger = LogManager.getLogger();
+    private static final Logger logger = LogManager.getLogger(RoomGameMap.class);
+
     @Inject
     private IRoomManager roomManager;
-
 
     private IRoom room;
     private IRoomTile[][] tiles;
     private int mapSize;
-
 
     private final Pool<TileMetadata> tileMetadataPool = Pool
             .from(new TileMetadataAllocator())
@@ -67,9 +66,8 @@ public class RoomGameMap implements IRoomGameMap {
             case 'U' -> 30;
             case 'V' -> 31;
             case 'W' -> 32;
-
             case 'X' -> Short.MAX_VALUE;
-            default -> throw new IllegalArgumentException(STR."Invalid character: \{tile}");
+            default -> throw new IllegalArgumentException("Invalid character: " + tile);
         };
     }
 
@@ -81,9 +79,12 @@ public class RoomGameMap implements IRoomGameMap {
     @Override
     public void init(IRoom room) {
         this.room = room;
-        if (this.getRoom().getModel() == null)
-            throw new IllegalArgumentException(STR."invalid room model \{this.getRoom().getData().getModelName()}");
-        
+        if (this.getRoom().getModel() == null) {
+            throw new IllegalArgumentException(
+                    "Invalid room model: " + this.getRoom().getData().getModelName()
+            );
+        }
+
         try {
             var map = this.getRoom().getModel().getHeightMap().split("\n");
             var maxX = map[0].length();
@@ -98,7 +99,7 @@ public class RoomGameMap implements IRoomGameMap {
                 }
             }
         } catch (Exception e) {
-            this.logger.error(e);
+            logger.error("Error initializing game map for room {}", this.getRoom().getData().getId(), e);
         }
     }
 
@@ -129,7 +130,6 @@ public class RoomGameMap implements IRoomGameMap {
                 result.add(currentMetadata);
             }
         }
-
 
         return tile.getMetadata();
     }
@@ -162,7 +162,7 @@ public class RoomGameMap implements IRoomGameMap {
 
     @Override
     public void destroy() {
-
+        // no-op
     }
 
     @Override
@@ -210,8 +210,7 @@ public class RoomGameMap implements IRoomGameMap {
         return x >= 0
                 && x < this.getMaxX()
                 && y >= 0
-                && y < this.getMaxY()
-                ;
+                && y < this.getMaxY();
     }
 
     @Override
@@ -243,8 +242,13 @@ public class RoomGameMap implements IRoomGameMap {
             metadata.setWalkableHeight(tile.getPosition().getZ());
             tile.getMetadata().add(metadata);
         } catch (Exception e) {
-            this.logger.error("error creating metadata room {} tile {}:{}", this.getRoom().getData().getId(),
-                    tile.getX(), tile.getY(), e);
+            logger.error(
+                    "Error creating metadata room {} tile {}:{}",
+                    this.getRoom().getData().getId(),
+                    tile.getX(),
+                    tile.getY(),
+                    e
+            );
         }
 
         final var itemsAt = this.getRoom().getObjectManager().getAllFloorItemsSortedAt(tile.getPosition());
@@ -260,8 +264,13 @@ public class RoomGameMap implements IRoomGameMap {
                 item.getStackHeight().ifPresent(metadata::setStackHeight);
                 tile.getMetadata().add(metadata);
             } catch (Exception e) {
-                this.logger.error("error creating metadata room {} tile {}:{}", this.getRoom().getData().getId(),
-                        tile.getX(), tile.getY(), e);
+                logger.error(
+                        "Error creating metadata room {} tile {}:{}",
+                        this.getRoom().getData().getId(),
+                        tile.getX(),
+                        tile.getY(),
+                        e
+                );
             }
         }
     }

--- a/emulator/src/main/java/habbo/rooms/components/objects/items/LimitedData.java
+++ b/emulator/src/main/java/habbo/rooms/components/objects/items/LimitedData.java
@@ -14,7 +14,7 @@ public record LimitedData(int limitedRare, int limitedRareTotal) implements ILim
 
     @Override
     public String toString() {
-        return STR."\{this.limitedRare}:\{this.limitedRareTotal}";
+        return limitedRare + ":" + limitedRareTotal;
     }
 
     @Override

--- a/emulator/src/main/java/habbo/rooms/components/objects/items/floor/interactions/SitFloorItem.java
+++ b/emulator/src/main/java/habbo/rooms/components/objects/items/floor/interactions/SitFloorItem.java
@@ -22,7 +22,11 @@ public class SitFloorItem extends DefaultFloorItem {
         final var position = entity.getPositionComponent().getPosition().copy();
         position.setZ(this.getPosition().getZ());
         entity.getPositionComponent().setPosition(position);
-        entity.getStatusComponent().setStatus(new StatusBucket(RoomEntityStatus.SIT, STR."\{(this.getPosition().getZ() + 1D)}"));
+
+        String sitHeight = String.valueOf(this.getPosition().getZ() + 1.0);
+        entity.getStatusComponent().setStatus(
+                new StatusBucket(RoomEntityStatus.SIT, sitHeight)
+        );
         entity.getStatusComponent().setNeedUpdateStatus(true);
     }
 }

--- a/emulator/src/main/java/habbo/rooms/entities/components/position/EntityPositionComponent.java
+++ b/emulator/src/main/java/habbo/rooms/entities/components/position/EntityPositionComponent.java
@@ -183,8 +183,14 @@ public class EntityPositionComponent implements IEntityPositionComponent {
 
         this.getEntity().getStatusComponent().removeStatus(RoomEntityStatus.SIT);
         this.getEntity().getStatusComponent().removeStatus(RoomEntityStatus.LAY);
-        this.getEntity().getStatusComponent().setStatus(new StatusBucket(RoomEntityStatus.MOVE,
-                STR."\{this.getNextPosition().getX()},\{this.getNextPosition().getY()},\{this.getNextPosition().getZ()}"));
+        this.getEntity().getStatusComponent().setStatus(
+                new StatusBucket(
+                        RoomEntityStatus.MOVE,
+                        this.getNextPosition().getX() + ","
+                                + this.getNextPosition().getY() + ","
+                                + this.getNextPosition().getZ()
+                )
+        );
         this.getEntity().getStatusComponent().setNeedUpdateStatus(true);
     }
 

--- a/networking/pom.xml
+++ b/networking/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>networking</artifactId>
 
     <properties>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.75.Final</version>
+            <version>4.2.1.Final</version>
         </dependency>
         <dependency>
             <groupId>org.orion</groupId>
@@ -44,9 +44,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
-                    <compilerArgs>--enable-preview</compilerArgs>
+                    <source>23</source>
+                    <target>23</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/networking/src/main/java/SSLCertificateLoader.java
+++ b/networking/src/main/java/SSLCertificateLoader.java
@@ -7,16 +7,16 @@ import java.io.File;
 
 public final class SSLCertificateLoader {
     private static final String filePath = "ssl";
-    private static final Logger logger = LogManager.getLogger();
+    private static final Logger logger = LogManager.getLogger(SSLCertificateLoader.class);
 
     public static SslContext getContext() {
-        SslContext context;
         try {
-            context = SslContextBuilder.forServer(new File(STR."\{filePath}\{File.separator}cert.pem"), new File(STR."\{filePath + File.separator}privkey.pem")).build();
-        } catch ( Exception e ) {
+            File certFile = new File(filePath + File.separator + "cert.pem");
+            File keyFile  = new File(filePath + File.separator + "privkey.pem");
+            return SslContextBuilder.forServer(certFile, keyFile).build();
+        } catch (Exception e) {
             logger.info("Unable to load ssl: {}", e.getMessage());
-            context = null;
+            return null;
         }
-        return context;
     }
 }

--- a/networking/src/main/java/decoders/GamePolicyDecoder.java
+++ b/networking/src/main/java/decoders/GamePolicyDecoder.java
@@ -11,7 +11,13 @@ import java.util.List;
 
 public class GamePolicyDecoder extends ByteToMessageDecoder {
 
-    private static final String POLICY = STR."<?xml version=\"1.0\"?>\n  <!DOCTYPE cross-domain-policy SYSTEM \"/xml/dtds/cross-domain-policy.dtd\">\n  <cross-domain-policy>\n  <allow-access-from domain=\"*\" to-ports=\"1-31111\" />\n  </cross-domain-policy>\{(char) 0}";
+    private static final String POLICY =
+            "<?xml version=\"1.0\"?>\n" +
+                    "  <!DOCTYPE cross-domain-policy SYSTEM \"/xml/dtds/cross-domain-policy.dtd\">\n" +
+                    "  <cross-domain-policy>\n" +
+                    "    <allow-access-from domain=\"*\" to-ports=\"1-31111\" />\n" +
+                    "  </cross-domain-policy>"
+                    + (char) 0;  // append the null terminator
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {

--- a/networking/src/main/java/packets/PacketManager.java
+++ b/networking/src/main/java/packets/PacketManager.java
@@ -52,10 +52,14 @@ public class PacketManager implements IPacketManager {
 
     @Override
     public void registerIncoming(IncomingEvent incomingEvent) {
-        this.logger.debug(STR."register incoming \{incomingEvent.getClass().getSimpleName()} with header id \{incomingEvent.getHeaderId()} from \{ReflectionHelpers.getCallerInfo()}");
+        logger.debug(
+                "register incoming {} with header id {} from {}",
+                incomingEvent.getClass().getSimpleName(),
+                incomingEvent.getHeaderId(),
+                ReflectionHelpers.getCallerInfo()
+        );
         this.internalRegisterIncoming(incomingEvent);
     }
-
 
     private void registerGuestEvent(IncomingEvent event) {
         this.guestEvents.put(event.getHeaderId(), event);

--- a/networking/src/main/java/packets/outgoing/catalog/CatalogIndexComposer.java
+++ b/networking/src/main/java/packets/outgoing/catalog/CatalogIndexComposer.java
@@ -30,7 +30,11 @@ public class CatalogIndexComposer extends OutgoingPacket {
         this.appendInt(catalogPage.getIcon());
         this.appendInt(catalogPage.isEnabled() ? catalogPage.getId() : -1);
         this.appendString(catalogPage.getCaption());
-        this.appendString(showId ? STR."\{catalogPage.getCaption()} (\{catalogPage.getId()})" : catalogPage.getCaption());
+        this.appendString(
+                showId
+                        ? catalogPage.getCaption() + " (" + catalogPage.getId() + ")"
+                        : catalogPage.getCaption()
+        );
         this.appendInt(0, "offer-ids size");
 
         this.appendInt(catalogPage.getChildren().size());

--- a/networking/src/main/java/packets/outgoing/purse/UserCreditsComposer.java
+++ b/networking/src/main/java/packets/outgoing/purse/UserCreditsComposer.java
@@ -8,6 +8,6 @@ public class UserCreditsComposer extends OutgoingPacket {
     public UserCreditsComposer(IHabbo habbo) {
         super(OutgoingHeaders.UserCreditsComposer);
 
-        this.appendString(STR."\{habbo.getData().getCredits()}");
+        this.appendString(Integer.toString(habbo.getData().getCredits()));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,11 @@
         <module>api</module>
         <module>networking</module>
         <module>storage</module>
-        <module>performance</module>
     </modules>
 
     <properties>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>storage</artifactId>
 
     <properties>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
@@ -31,9 +31,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
-                    <compilerArgs>--enable-preview</compilerArgs>
+                    <source>23</source>
+                    <target>23</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/storage/src/main/java/connectors/HikariConnector.java
+++ b/storage/src/main/java/connectors/HikariConnector.java
@@ -24,7 +24,7 @@ public class HikariConnector implements IConnector {
         try {
             this.initializeHikari();
         } catch (Exception e) {
-            this.logger.error(STR."Failed to initialize Hikari: \{e.getMessage()}");
+            this.logger.error("Failed to initialize Hikari:{}", e.getMessage());
         }
     }
 
@@ -33,7 +33,15 @@ public class HikariConnector implements IConnector {
 
         databaseConfiguration.setMaximumPoolSize(this.config.getInt("db.pool.maxsize", 50));
         databaseConfiguration.setMinimumIdle(this.config.getInt("db.pool.minsize", 10));
-        databaseConfiguration.setJdbcUrl(STR."jdbc:mysql://\{this.config.getString("db.hostname", "localhost")}:\{this.config.getString("db.port", "3306")}/\{this.config.getString("db.database", "habbo")}\{this.config.getString("db.params")}");
+        databaseConfiguration.setJdbcUrl(
+                "jdbc:mysql://"
+                        + this.config.getString("db.hostname", "localhost")
+                        + ":"
+                        + this.config.getString("db.port", "3306")
+                        + "/"
+                        + this.config.getString("db.database", "habbo")
+                        + this.config.getString("db.params", "")
+        );
         databaseConfiguration.addDataSourceProperty("serverName", this.config.getString("db.hostname", "localhost"));
         databaseConfiguration.addDataSourceProperty("port", this.config.getString("db.port", "3306"));
         databaseConfiguration.addDataSourceProperty("databaseName", this.config.getString("db.database", "habbo"));

--- a/storage/src/main/java/repositories/ConnectionRepository.java
+++ b/storage/src/main/java/repositories/ConnectionRepository.java
@@ -41,7 +41,7 @@ public class ConnectionRepository implements IConnectionRepository {
                 resultConsumer.accept(connectionResult);
             }
         } catch (Exception e) {
-            this.logger.error(STR."Error while executing SELECT query: \{query}", e);
+            this.logger.error("Error while executing SELECT query:{}", query, e);
         } finally {
             this.connection.getConnectionContext().getProvider().closeResultSet(selectResult);
             this.connection.getConnectionContext().getProvider().closeStatement(preparedStatement);
@@ -70,7 +70,7 @@ public class ConnectionRepository implements IConnectionRepository {
                 resultConsumer.accept(connectionResult);
             }
         } catch (Exception e) {
-            this.logger.error(STR."Error while executing UPDATE query: \{query}", e);
+            this.logger.error("Error while executing UPDATE query:{}", query, e);
         } finally {
             this.connection.getConnectionContext().getProvider().closeResultSet(updateResult);
             this.connection.getConnectionContext().getProvider().closeStatement(preparedStatement);
@@ -94,7 +94,7 @@ public class ConnectionRepository implements IConnectionRepository {
 
             consumer.accept(isUpdated);
         } catch (Exception e) {
-            this.logger.error(STR."Error while executing UPDATE query: \{query}", e);
+            this.logger.error("Error while executing UPDATE query:{}", query, e);
         } finally {
             this.connection.getConnectionContext().getProvider().closeStatement(preparedStatement);
             this.connection.getConnectionContext().getProvider().closeConnection(connection);
@@ -122,7 +122,7 @@ public class ConnectionRepository implements IConnectionRepository {
                 resultConsumer.accept(connectionResult);
             }
         } catch (Exception e) {
-            this.logger.error(STR."Error while executing INSERT query: \{query}", e);
+            this.logger.error("Error while executing INSERT query:{}", query, e);
         } finally {
             this.connection.getConnectionContext().getProvider().closeResultSet(insertResult);
             this.connection.getConnectionContext().getProvider().closeStatement(preparedStatement);
@@ -151,7 +151,7 @@ public class ConnectionRepository implements IConnectionRepository {
                 consumer.accept(connectionResult);
             }
         } catch (Exception e) {
-            this.logger.error(STR."Error while executing INSERT query: \{query}", e);
+            this.logger.error("Error while executing INSERT query:{}", query, e);
         } finally {
             this.connection.getConnectionContext().getProvider().closeResultSet(insertResult);
             this.connection.getConnectionContext().getProvider().closeStatement(preparedStatement);
@@ -174,7 +174,7 @@ public class ConnectionRepository implements IConnectionRepository {
 
             consumer.accept(isDeleted);
         } catch (Exception e) {
-            this.logger.error(STR."Error while executing DELETE query: \{query}", e);
+            this.logger.error("Error while executing DELETE query:{}", query, e);
         } finally {
             this.connection.getConnectionContext().getProvider().closeStatement(preparedStatement);
             this.connection.getConnectionContext().getProvider().closeConnection(connection);


### PR DESCRIPTION
This PR modernizes and cleans up our string interpolation and logging throughout the codebase, and brings our preview‐feature support in line with the latest JDK:

- Removed all STR."…{…}" literals and replaced them with
- Standard Java string concatenation (+) for exceptions and error messages
- Log4j’s parameterized {} placeholders for logging calls
- Updated exception messages and logging calls to use consistent, idiomatic patterns
- Bumped Java compilation target and preview flag from 22 to 23 in our build configuration